### PR TITLE
Update the guideline of RFC tracking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ the RFC process:
     - The formal RFC may link back to the original discussion if there is
       additional context or discussion, but all of the final feature design
       must be completely described in the pull request.
-- **Tracking Issue**: Upon merging a RFC, a tracking issue will be created in
-  the main TVM repository, where implementors can continue sharing
+- **Tracking Issue**: When the RFC review is nearly done and about to merge,
+  a tracking issue will be created in the main TVM repository with the
+  *rfc-tracking* label (added by a committer), where implementors can continue sharing
   implementation details (including links to pull requests). The issue will be
   closed when the RFC is either completed or postponed.
 - **Implementation**: Work will begin on the RFC, with pull requests linking

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ the RFC process:
       must be completely described in the pull request.
 - **Tracking Issue**: When the RFC review is nearly done and about to merge,
   a tracking issue will be created in the main TVM repository with the
-  *rfc-tracking* label (added by a committer), where implementors can continue sharing
+  title "[RFC][Tracking][<RFC-no.>] <RFC-title>" and *rfc-tracking* label
+  (added by a committer), where implementors can continue sharing
   implementation details (including links to pull requests). The issue will be
   closed when the RFC is either completed or postponed.
 - **Implementation**: Work will begin on the RFC, with pull requests linking

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ the RFC process:
     - The formal RFC may link back to the original discussion if there is
       additional context or discussion, but all of the final feature design
       must be completely described in the pull request.
-- **Tracking Issue**: When the RFC review is nearly done and about to merge,
-  a tracking issue will be created in the main TVM repository with the
+- **Tracking Issue**: When the RFC review is about to merge, a committer
+  should remind authors to open a tracking issue in the main TVM repository with the
   title "[RFC][Tracking][<RFC-no.>] <RFC-title>" and *rfc-tracking* label
   (added by a committer), where implementors can continue sharing
   implementation details (including links to pull requests). The issue will be


### PR DESCRIPTION
Based on the two RFCs I've reviewed, there are two points related to the RFC tracking issue that could be improved IMHO.

1. We currently state that the tracking issue should be opened after the RFC PR is merged. However, it means the author needs to file another PR to update the issue link, which seems not necessary to me. As a result, I refined the description, saying that the issue should be opened when the review is nearly done. The reviewer should also remind authors to open a tracking issue and update the link before merging the RFC PR.
2. To better tracking the RFC issues, I created a new label "rfc-tracking". It would be better to add this label to all RFC tracking issues associated with the RFCs proposed here.